### PR TITLE
Install test-requirements as part of release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: get current version
         run: |
+          pip install -r test-requirements.txt
           echo "current_version=$(make show-version)" >> $GITHUB_ENV
       - uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
 * Needed to install test-requirements so that bumpversion
   was available that way we could use the make show-version
   command