### PR TITLE
Update create_release workflow to use PAT

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -22,4 +22,5 @@ jobs:
           tag: v${{ env.current_version }}
           commit: ${{ github.sha }}
           bodyFile: "current_release.md"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          #Using my PAT because using the Github App Token does not support cascading triggering
+          token: ${{ secrets.GIT_TOKEN }}


### PR DESCRIPTION
 * switched to using the PAT vs the GitHub App token
   because it does not support cascading triggering
   of workflows that utilize the token