### PR TITLE
remove some of the release triggers for publish_package workflow

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -3,7 +3,7 @@ name: "Push the master branch to pypi when new release is created"
 on:
   workflow_dispatch:
   release:
-    types: [released, published, created]
+    types: [published]
 
 jobs:
   deploy_pypi:


### PR DESCRIPTION
 * Removed the release trigger released/created to avoid
   redudant trigged failures now that that workflows are
   using the correct token